### PR TITLE
Improvements on tile requests: http status codes and source reloading

### DIFF
--- a/lib/tiles.js
+++ b/lib/tiles.js
@@ -56,8 +56,19 @@ function requestHandler(req, res, next) {
   let opts;
 
   return Promise.try(() => {
-    source = core.getPublicSource(params.src);
-
+    let p = Promise.resolve();
+    if (core.getConfiguration().reloadSourcesOnGetTile) {
+      const sources = core.getSources();
+      const src = sources.getSourceById(params.src, true, true);
+      if (src && src.isDisabled) {
+        // Reload all sources
+        p = p.then(() => sources.loadSourcesAsync(sources.getSourceConfigs()));
+      }
+    }
+    return p.then(() => {
+      source = core.getPublicSource(params.src);
+    });
+  }).then(() => {
     if (!_.contains(source.formats, params.format)) {
       throw new Err('Format %s is not known', params.format).metrics('err.req.format');
     }
@@ -115,7 +126,9 @@ function requestHandler(req, res, next) {
       mx += `.${params.scale.toString().replace('.', ',')}`;
     }
     core.metrics.endTiming(mx, start);
-  }).catch(err => core.reportRequestError(err, res)).catch(next);
+  })
+    .catch(err => core.reportRequestError(err, res))
+    .catch(next);
 }
 
 module.exports = function tiles(cor, router) {

--- a/lib/tiles.js
+++ b/lib/tiles.js
@@ -109,23 +109,28 @@ function requestHandler(req, res, next) {
     return source.getHandler();
   })
     .catch(err => core.reportRequestError(err, res))
-    .then(handler => handler.getAsync(opts))
-    .then((result) => {
-      core.setResponseHeaders(res, source, result.headers);
-
-      if (params.format === 'json') {
-      // Allow JSON to be shortened to simplify debugging
-        res.json(filterJson(req.query, result.data));
-      } else {
-        res.send(result.data);
+    .then((handler) => {
+      if (handler === undefined) {
+        return undefined;
       }
 
-      let mx = util.format('req.%s.%s.%s', params.src, params.z, params.format);
-      if (params.scale) {
-      // replace '.' with ',' -- otherwise grafana treats it as a divider
-        mx += `.${params.scale.toString().replace('.', ',')}`;
-      }
-      core.metrics.endTiming(mx, start);
+      return handler.getAsync(opts).then((result) => {
+        core.setResponseHeaders(res, source, result.headers);
+
+        if (params.format === 'json') {
+        // Allow JSON to be shortened to simplify debugging
+          res.json(filterJson(req.query, result.data));
+        } else {
+          res.send(result.data);
+        }
+
+        let mx = util.format('req.%s.%s.%s', params.src, params.z, params.format);
+        if (params.scale) {
+        // replace '.' with ',' -- otherwise grafana treats it as a divider
+          mx += `.${params.scale.toString().replace('.', ',')}`;
+        }
+        core.metrics.endTiming(mx, start);
+      });
     })
     .catch(next);
 }

--- a/lib/tiles.js
+++ b/lib/tiles.js
@@ -132,6 +132,20 @@ function requestHandler(req, res, next) {
         core.metrics.endTiming(mx, start);
       });
     })
+    .catch((err) => {
+      if (core.isNoTileError(err)) {
+        /* eslint-disable-next-line no-throw-literal */
+        throw {
+          /* This object will be caught by kartotherian
+            custom error handler to log and build
+            a proper HTTP error */
+          status: 404,
+          message: err.message,
+          type: err.name,
+        };
+      }
+      throw err;
+    })
     .catch(next);
 }
 

--- a/lib/tiles.js
+++ b/lib/tiles.js
@@ -106,28 +106,27 @@ function requestHandler(req, res, next) {
 
     // fixme: Force all tiles to be treated as vector
     opts.treatAsVector = true;
-
-    return source.getHandler().getAsync(opts);
-  }).then((result) => {
-    let mx;
-
-    core.setResponseHeaders(res, source, result.headers);
-
-    if (params.format === 'json') {
-      // Allow JSON to be shortened to simplify debugging
-      res.json(filterJson(req.query, result.data));
-    } else {
-      res.send(result.data);
-    }
-
-    mx = util.format('req.%s.%s.%s', params.src, params.z, params.format);
-    if (params.scale) {
-      // replace '.' with ',' -- otherwise grafana treats it as a divider
-      mx += `.${params.scale.toString().replace('.', ',')}`;
-    }
-    core.metrics.endTiming(mx, start);
+    return source.getHandler();
   })
     .catch(err => core.reportRequestError(err, res))
+    .then(handler => handler.getAsync(opts))
+    .then((result) => {
+      core.setResponseHeaders(res, source, result.headers);
+
+      if (params.format === 'json') {
+      // Allow JSON to be shortened to simplify debugging
+        res.json(filterJson(req.query, result.data));
+      } else {
+        res.send(result.data);
+      }
+
+      let mx = util.format('req.%s.%s.%s', params.src, params.z, params.format);
+      if (params.scale) {
+      // replace '.' with ',' -- otherwise grafana treats it as a divider
+        mx += `.${params.scale.toString().replace('.', ',')}`;
+      }
+      core.metrics.endTiming(mx, start);
+    })
     .catch(next);
 }
 


### PR DESCRIPTION
* Define a flag `reloadSourcesOnGetTile` in the service configuration, to try to reload sources when fetching a tile from a disabled source
* Use `core.reportRequestError` to handle bad requests only (and send HTTP 400)
* Catch "no tile error" to send 404 status

Note that the server responses may still be inconsistent when a source is unavailable.  
For example, if a cassandra database is not reachable, workers that have never been connected to cassandra will send "400" responses (because the source is disabled, and the request is considered as invalid); whereas workers that already have a connection to the database will send "500" responses (connection lost).
In both cases, workers will attempt to reconnect to the database, and will work normally eventually, when the db is reachable again.